### PR TITLE
Add support for enum Fields

### DIFF
--- a/examples/example_agent.py
+++ b/examples/example_agent.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 from pydantic import Field
 
@@ -27,6 +28,7 @@ class ExampleAgent(mk.Agent[ExampleContext]):
             ReplaceAction,
             ConcatAction,
             PadAction,
+            CaseAction,
         )
 
 
@@ -39,7 +41,6 @@ class ReplaceAction(mk.Action):
 
     def perform(self, context: ExampleContext) -> str:
         context._text = self.text
-        print(f"Text result: {context._text}")
         return context._text
 
 
@@ -52,7 +53,6 @@ class ConcatAction(mk.Action):
 
     def perform(self, context: ExampleContext) -> str:
         context._text += self.text
-        print(f"Action result: {context._text}")
         return context._text
 
 
@@ -79,14 +79,45 @@ class PadAction(mk.Action):
     )
 
     def perform(self, context: ExampleContext) -> str:
-        text = context._text
         if self.start and self.start > 0:
-            text = self.text * self.start + text
+            context._text = self.text * self.start + context._text
         if self.end and self.end > 0:
-            text = text + self.text * self.end
-        context._text = text
+            context._text = context._text + self.text * self.end
+        return context._text
 
-        print(f"Padded text result: {text}")
+
+class CaseOperation(Enum):
+    UPPER = "upper"
+    LOWER = "lower"
+    TITLE = "title"
+    CAPITALIZE = "capitalize"
+    SWAPCASE = "swapcase"
+    CASEFOLD = "casefold"
+
+
+@mk.action_name(
+    name="case",
+    description="Changes the case of the text.",
+)
+class CaseAction(mk.Action):
+    operation: Optional[CaseOperation] = Field(
+        default=CaseOperation.UPPER,
+        description="The type of operation to perform on the text.",
+    )
+
+    def perform(self, context: ExampleContext) -> str:
+        if self.operation == CaseOperation.UPPER:
+            context._text = context._text.upper()
+        elif self.operation == CaseOperation.LOWER:
+            context._text = context._text.lower()
+        elif self.operation == CaseOperation.TITLE:
+            context._text = context._text.title()
+        elif self.operation == CaseOperation.CAPITALIZE:
+            context._text = context._text.capitalize()
+        elif self.operation == CaseOperation.SWAPCASE:
+            context._text = context._text.swapcase()
+        elif self.operation == CaseOperation.CASEFOLD:
+            context._text = context._text.casefold()
         return context._text
 
 

--- a/examples/example_cli.py
+++ b/examples/example_cli.py
@@ -7,5 +7,6 @@ if __name__ == "__main__":
     agent = ExampleAgent()
     agent.attach(ExampleContext())
     arg_parser = AgentArgParser(agent)
-    arg_parser.parse_and_perform()
+    result = arg_parser.parse_and_perform()
+    print(f"Action result: {result}")
     agent.detach()

--- a/tests/test_agent_arg_parser.py
+++ b/tests/test_agent_arg_parser.py
@@ -54,6 +54,17 @@ class TestAgentArgParser(unittest.TestCase):
         text = self.parser.parse_and_perform()
         self.assertEqual(text, "Initial state is padded is padded is padded")
 
+    @patch(
+        "argparse.ArgumentParser.parse_args",
+        return_value=Namespace(action="case", operation="upper"),
+    )
+    def test_case_action_enum_parameters(self, _):
+        """Test that replace action is parsed correctly when context is present."""
+        context = ExampleContext()
+        self.agent.attach(context)
+        text = self.parser.parse_and_perform()
+        self.assertEqual(text, "INITIAL STATE")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_example_agent.py
+++ b/tests/test_example_agent.py
@@ -18,7 +18,7 @@ class TestExampleAgent(unittest.IsolatedAsyncioTestCase):
         description = self.agent.describe()
         self.assertEqual(description["name"], "example-agent")
         self.assertEqual(description["role"], "Manages text state")
-        self.assertEqual(len(description["actions"]), 3)
+        self.assertEqual(len(description["actions"]), 4)
 
     def test_perform_action(self):
         """Test the agent can perform an action."""


### PR DESCRIPTION
Add an example action using Enum. Making it easier to find the options available for parameters. Here's the command line
```
(modlink-py3.12) ➜  modlink git:(km-support-enum-parameters) python -m examples.example_cli case -h
usage: example_cli.py case [-h] [--operation {upper,lower,title,capitalize,swapcase,casefold}]

options:
  -h, --help            show this help message and exit
  --operation {upper,lower,title,capitalize,swapcase,casefold}
                        The type of operation to perform on the text.
```

```
class CaseOperation(Enum):
    UPPER = "upper"
    LOWER = "lower"
    TITLE = "title"
    CAPITALIZE = "capitalize"
    SWAPCASE = "swapcase"
    CASEFOLD = "casefold"


@mk.action_name(
    name="case",
    description="Changes the case of the text.",
)
class CaseAction(mk.Action):
    operation: Optional[CaseOperation] = Field(
        default=CaseOperation.UPPER,
        description="The type of operation to perform on the text.",
    )

    def perform(self, context: ExampleContext) -> str:
        if self.operation == CaseOperation.UPPER:
            context._text = context._text.upper()
        elif self.operation == CaseOperation.LOWER:
            context._text = context._text.lower()
        elif self.operation == CaseOperation.TITLE:
            context._text = context._text.title()
        elif self.operation == CaseOperation.CAPITALIZE:
            context._text = context._text.capitalize()
        elif self.operation == CaseOperation.SWAPCASE:
            context._text = context._text.swapcase()
        elif self.operation == CaseOperation.CASEFOLD:
            context._text = context._text.casefold()
        return context._text
```