### PR TITLE
Fix bug where fields could not contain action

### DIFF
--- a/example/actions/timestamp.py
+++ b/example/actions/timestamp.py
@@ -1,0 +1,20 @@
+from datetime import date
+from typing import Optional
+from pydantic import Field
+from modlink.action import Action, action_name
+
+from example.context import ExampleContext
+
+
+@action_name(
+    name="timestamp",
+    description="Adds a timestamp to the text.",
+)
+class TimestampAction(Action):
+    transaction: Optional[date] = Field(
+        description="Transaction ID for the action.",
+    )
+
+    def perform(self, context: ExampleContext) -> str:
+        context.text = f"{self.transaction}: {context.text}"
+        return context.text

--- a/tests/test_agent_arg_parser.py
+++ b/tests/test_agent_arg_parser.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 import unittest
 from unittest.mock import patch
 from example.actions.replace import ReplaceAction
+from example.actions.timestamp import TimestampAction
 from example.agent import ExampleAgent
 from example.context import ExampleContext
 from modlink.tools import AgentArgParser
@@ -95,6 +96,22 @@ class TestAgentArgParser(unittest.TestCase):
         self.agent.attach(context)
         text: str = self.parser.parse_and_perform()
         self.assertEqual(text, "VillageYosemiteValley")
+
+    def test_action_with_action_field(self):
+        """Test the a word like trans-action which contains action in the field."""
+        context = ExampleContext()
+        context.text = "Today is the day."
+        self.agent.attach(context)
+        self.parser = AgentArgParser(self.agent)
+
+        result: TimestampAction = self.parser.parse_args(
+            args=[
+                "timestamp",
+                "--transaction",
+                "2024-11-01",
+            ],
+        )
+        self.assertEqual(str(result.transaction), "2024-11-01")
 
 
 if __name__ == "__main__":

--- a/tests/test_example_agent.py
+++ b/tests/test_example_agent.py
@@ -21,7 +21,7 @@ class TestExampleAgent(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(description["name"], "example-agent")
         self.assertEqual(description["role"], "Edits text state")
-        self.assertEqual(len(description["actions"]), 6)
+        self.assertEqual(len(description["actions"]), 7)
 
     def test_perform_action(self):
         """Test the agent can perform an action."""


### PR DESCRIPTION
Tried to make an Action with the field transaction but it is ignored because it contains "action". Dumb. But this fixes it.